### PR TITLE
Adding the start of some multiserver functionality

### DIFF
--- a/handshakeHandler.js
+++ b/handshakeHandler.js
@@ -1,0 +1,84 @@
+const SERVER_LOGGING = true;
+keepAliveSendInterval = 15000
+keepAliveMaxWaitForResponse = 30000
+
+const Utility = require('./utility.js');
+const log = Utility.log
+const net = require('net');
+const Packet = require('./packet.js');
+const Handshake = require('./packets/serverbound/handshake.js');
+const LoginStart = require('./packets/serverbound/loginStart.js');
+const LoginSuccess = require('./packets/clientbound/loginSuccess.js');
+const StatusResponse = require('./packets/clientbound/statusResponse.js');
+const SpawnPosition = require('./packets/clientbound/spawnPosition.js');
+const PlayerPosition = require('./packets/clientbound/playerPosition.js');
+const ChunkData = require('./packets/clientbound/chunkData.js');
+const JoinGame = require('./packets/clientbound/joinGame.js');
+const KeepAlive = require('./packets/clientbound/keepAlive.js');
+
+const sampleStatus = `{
+    "version": {
+        "name": "1.13.2",
+        "protocol": 404
+    },
+    "players": {
+        "max": 100,
+        "online": 0,
+        "sample": []
+    },
+    "description": {
+        "text": "Hello world"
+    }
+}`
+
+class HandshakeHandler {
+    constructor(socket) {
+      this.state = 0
+      this.socket = socket
+    }
+
+    socketData(data) {
+      var packets = Packet.loadFromBuffer(data)
+      for(var i = 0; i < packets.length; i++){
+        var packet = packets[i]
+        if(this.state == 0) { //PreHandshake
+          switch(packet.packetID) {
+            case 0:
+              var handshake = new Handshake(packet)
+              this.state = handshake.nextState
+              log(`handshake with state ${this.state}`)
+              break;
+            default:
+              log(`state 3: unexpected packet id ${packet.packetID}`)
+          }
+        } else if(this.state == 1) { //PostStatusHandshake
+          switch(packet.packetID) {
+            case 0:
+              var statusResponse = new StatusResponse(sampleStatus)
+              log(`sending status..`)
+              this.socket.write(statusResponse.loadIntoBuffer())
+              break;
+            case 1:
+              this.socket.write(packet.loadIntoBuffer())
+              break;
+            default:
+              log(`unexpected packet id ${packet.packetID}`)
+              break;
+          }
+        } else if(this.state == 2) { //PostLoginHandshake
+          switch(packet.packetID){
+            case 0:
+              var loginStart = new LoginStart(packet)
+              log(`User ${loginStart.username} is logging in...`)
+              return loginStart.username
+            default:
+              log(`state 2: unexpected packet id ${packet.packetID}`)
+              break;
+          }
+        }
+      }
+      return null;
+    }
+}
+
+module.exports = HandshakeHandler

--- a/playerRouter.js
+++ b/playerRouter.js
@@ -1,0 +1,7 @@
+class PlayerRouter {
+  static getHost(username) {
+    return { port: 8001 }
+  }
+}
+
+module.exports = PlayerRouter

--- a/regionServer/regionServer.js
+++ b/regionServer/regionServer.js
@@ -1,0 +1,31 @@
+const Utility = require('../utility.js');
+const log = Utility.log
+const net = require('net');
+const server = net.createServer();
+const hostname = '127.0.0.1';
+const port = 8001;
+
+const SocketDataHandler = require('../socketDataHandler.js');
+
+server.on('connection', socket => {
+  var handler = new SocketDataHandler(socket)
+
+  socket.on('close', err => {
+    handler.close()
+    if(err){ log('socket closed due to error') } else { log('socket closed') }
+  })
+  socket.on('error', err => {
+    console.log(err)
+  })
+  socket.on('data', data => {
+    handler.socketData(data)
+  })
+});
+
+server.on('close', socket => {
+  log('server closed');
+});
+
+server.listen(port, hostname, () => {
+  log('server on');
+});

--- a/server.js
+++ b/server.js
@@ -4,21 +4,36 @@ const net = require('net');
 const server = net.createServer();
 const hostname = '127.0.0.1';
 const port = 8000;
+const HandshakeHandler = require('./handshakeHandler.js')
+const PlayerRouter = require('./playerRouter.js')
 
-const SocketDataHandler = require('./socketDataHandler.js');
 
 server.on('connection', socket => {
-  var handler = new SocketDataHandler(socket)
+  var state = 0
+  var handler = new HandshakeHandler(socket)
+  var chunkSocket = null
 
   socket.on('close', err => {
-    handler.close()
+    if(chunkSocket) { chunkSocket.end() }
     if(err){ log('socket closed due to error') } else { log('socket closed') }
   })
   socket.on('error', err => {
     console.log(err)
   })
   socket.on('data', data => {
-    handler.socketData(data)
+    if(state == 0) {
+      username = handler.socketData(data)
+      if(username) {
+        var connectionOptions = PlayerRouter.getHost(username)
+        chunkSocket = net.createConnection(connectionOptions, () => {
+          log('connected to chunk')
+        })
+        chunkSocket.on('data', data => { socket.write(data) })
+        state = 1
+      }
+    } else {
+      chunkSocket.write(data)
+    }
   })
 });
 

--- a/socketDataHandler.js
+++ b/socketDataHandler.js
@@ -4,6 +4,7 @@ keepAliveMaxWaitForResponse = 30000
 
 const Utility = require('./utility.js');
 const log = Utility.log
+const net = require('net');
 const Packet = require('./packet.js');
 const Handshake = require('./packets/serverbound/handshake.js');
 const LoginStart = require('./packets/serverbound/loginStart.js');
@@ -30,15 +31,34 @@ const sampleStatus = `{
     }
 }`
 
+//Eventually the edge server will pass this through
+var username = 'gogo_the_monkey'
+
 class SocketDataHandler {
     constructor(socket) {
-        this.state = 0
-        this.socket = socket
-        this.keepAliveTimeout = []
+      this.socket = socket
+      this.keepAliveTimeout = []
+      var loginSuccess = new LoginSuccess(username)
+      this.socket.write(loginSuccess.loadIntoBuffer())
+      var joinGame = new JoinGame(username)
+      this.socket.write(joinGame.loadIntoBuffer())
+      var spawnPosition = new SpawnPosition(0,3,0)
+      this.socket.write(spawnPosition.loadIntoBuffer())
+      for(var x = -4; x <= 4; x++){
+        for(var z = -4; z <= 4; z++){
+          var loadChunk = new ChunkData(x,z)
+          this.socket.write(loadChunk.loadIntoBuffer())
+        }
+      }
+      var playerPosition = new PlayerPosition(0,30,0,0,0)
+      this.socket.write(playerPosition.loadIntoBuffer())
+      this.state = 4
+      this.keepAliveInterval = setInterval(this.keepAlive.bind(this), keepAliveSendInterval)
     }
 
     close() {
         clearInterval(this.keepAliveInterval)
+        if(this.chunkSocket) { this.chunkSocket.end() }
     }
 
     keepAlive() {
@@ -46,78 +66,16 @@ class SocketDataHandler {
       this.keepAliveTimeout.push(setTimeout(() => this.socket.destroy(), keepAliveMaxWaitForResponse))
       this.socket.write(this.keepAlivePacket.loadIntoBuffer());
     }
-  
+
     socketData(data) {
       Packet.loadFromBuffer(data).forEach(packet => {
-        if(this.state == 0) { //PreHandshake
-          switch(packet.packetID) {
-            case 0:
-              var handshake = new Handshake(packet)
-              this.state = handshake.nextState
-              log(`handshake with state ${this.state}`)
-              break;
-            default:
-              log(`state 3: unexpected packet id ${packet.packetID}`)
-          }
-        } else if(this.state == 1) { //PostStatusHandshake
-          switch(packet.packetID) {
-            case 0:
-              var statusResponse = new StatusResponse(sampleStatus)
-              log(`sending status..`)
-              this.socket.write(statusResponse.loadIntoBuffer())
-              break;
-            case 1:
-              this.socket.write(packet.loadIntoBuffer())
-              break;
-            default:
-              log(`unexpected packet id ${packet.packetID}`)
-              break;
-          }
-        } else if(this.state == 2) { //PostLoginHandshake
-          switch(packet.packetID){
-            case 0:
-              var loginStart = new LoginStart(packet)
-              log(`User ${loginStart.username} is logging in...`)
-              var loginSuccess = new LoginSuccess(loginStart.username)
-              this.socket.write(loginSuccess.loadIntoBuffer())
-              var joinGame = new JoinGame(loginStart.username)
-              this.socket.write(joinGame.loadIntoBuffer())
-              var spawnPosition = new SpawnPosition(0,3,0)
-              this.socket.write(spawnPosition.loadIntoBuffer())
-              for(var x = -4; x <= 4; x++){
-                for(var z = -4; z <= 4; z++){
-                  var loadChunk = new ChunkData(x,z)
-                  this.socket.write(loadChunk.loadIntoBuffer())
-                }
-              }
-              var playerPosition = new PlayerPosition(0,30,0,0,0)
-              this.socket.write(playerPosition.loadIntoBuffer())
-              this.state = 4
-              this.keepAliveInterval = setInterval(this.keepAlive.bind(this), keepAliveSendInterval)
-              break;
-            default:
-              log(`state 2: unexpected packet id ${packet.packetID}`)
-              break;
-          }
-        } else if(this.state == 3) {
-          switch(packet.packetID) {
-            case 0:
-              log(`teleport confirm`)
-              this.state = 4
-              break;
-            default:
-              log(`state 3: unexpected packet id ${packet.packetID}`)
-              break;
-          }
-        } else { //Play
-          switch(packet.packetID) {
-            case 0x0E:
-              if (!packet.dataEquals(this.keepAlivePacket)) {
-                this.socket.destroy()
-              }
-              this.keepAliveTimeout.forEach(clearTimeout)
-              break;
-          }
+        switch(packet.packetID) {
+          case 0x0E:
+            if (!packet.dataEquals(this.keepAlivePacket)) {
+              this.socket.destroy()
+            }
+            this.keepAliveTimeout.forEach(clearTimeout)
+            break;
         }
       });
     }


### PR DESCRIPTION
Starting laying out the groundwork for how the server will be distributed.

-Created a new entrypoint for the region based servers  Essentially the role of the outer server is just to determine what server is hosting that players region. I'm calling them 'regions' instead of 'chunks' because I don't think that a chunk is an optimal size to have a separate instance at, and eventually you would want that number to be dynamic and the regions that individual instances cover could increase and decrease with traffic or other patterns. The role of the new server is to manage the game logic. It will know about all the entities and blocks in its region, it will pass packets along to the outer server to be sent to the client, and it will communicate to other region servers when necessary (i.e. if the player exists one region and goes into another).

-Split socket data handler into two files. One for handling the handshake that is used by the edge server, the one the user connects to initially and another for handling play packets that is used by the region servers.

-This changes how we have to run the server locally. In two separate windows run these commands:
```
node server.js
node regionServer/regionServer.js
```

Obviously a lot of this is hardcoded right now, we only one region server with a hardcoded port and address. I've also hardcoded the username- I don't think that actually matters atm, but eventually the outer server and the region server would have a protocol of their own to communicate things like that.