### PR TITLE
added expanding chunk map

### DIFF
--- a/bufferGenerators.js
+++ b/bufferGenerators.js
@@ -1,11 +1,16 @@
 const Int64BE = require("int64-buffer").Int64BE;
 const ByteStream = require("./byteStream.js");
+const uuidParse = require("uuid-parse");
 
 class BufferGenerators {
   static lengthPrefixedStringBuffer(str) {
     var strLengthBuffer = BufferGenerators.varIntBuffer(str.length);
     var strBuffer = Buffer.from(str)
     return Buffer.concat([strLengthBuffer, strBuffer])
+  }
+
+  static uuidBuffer(uuid) {
+    return Buffer.from(uuidParse.parse(uuid))
   }
 
   static positionBuffer(x,y,z) {
@@ -38,6 +43,12 @@ class BufferGenerators {
   static intBuffer(value) {
     var b = Buffer.alloc(4)
     b.writeInt32BE(value)
+    return b
+  }
+
+  static shortBuffer(value) {
+    var b = Buffer.alloc(2)
+    b.writeInt16BE(value)
     return b
   }
 

--- a/byteStream.js
+++ b/byteStream.js
@@ -84,6 +84,10 @@ class ByteStream {
     this.i += 4
   }
 
+  skipUuid() {
+    this.i += 16
+  }
+
   readDouble() {
     var value = this.buffer.readDoubleBE(this.i)
     this.i += 8
@@ -93,6 +97,14 @@ class ByteStream {
   writeDouble(val) {
     this.buffer.writeDoubleBE(val, this.i)
     this.i += 8
+  }
+
+  amendDouble(f) {
+    var d = this.readDouble()
+    console.log(`amend d ${d}`)
+    console.log(`into ${f(d)}`)
+    this.i -= 8
+    this.writeDouble(f(d))
   }
 
   readByteArray() {

--- a/chunkMap.js
+++ b/chunkMap.js
@@ -1,0 +1,103 @@
+class ChunkMap {
+  constructor() {
+    this.grid = new ExpandingGrid({localhost: true})
+    this.emptyPositions = []
+    this.nextPositions = [new Position(1, 0), new Position(-1,0), new Position(0, -1), new Position(0, 1)]
+  }
+
+  map(f) {
+    this.grid.map(f)
+  }
+
+  getServer(x,z) {
+    return this.grid.get(new Position(x,z))
+  }
+
+  allocateServer(serverInfo) {
+    var emptyPosition = this.emptyPositions.pop()
+    if(emptyPosition) {
+      this.grid.set(emptyPosition, serverInfo)
+    } else {
+      var nextPosition = this.nextPositions.pop()
+      if(this.nextPositions.length == 0) {
+        var x = Math.abs(nextPosition.x)
+        var z = Math.abs(nextPosition.z)
+        if(x == z) {
+          x++
+          z = 0
+        } else {
+          z++
+        }
+        this.nextPositions.push(new Position(x,z))
+        if(x != 0) {
+          this.nextPositions.push(new Position(-x,z))
+        }
+        if(z != 0) {
+          this.nextPositions.push(new Position(x,-z))
+        }
+        if(x != 0 && z != 0) {
+          this.nextPositions.push(new Position(-x,-z))
+        }
+        if(x != z) {
+          var len = this.nextPositions.length
+          for(var i = 0; i < len; i++) {
+            this.nextPositions.push(new Position(this.nextPositions[i].z, this.nextPositions[i].x))
+          }
+        }
+        console.log(this.nextPositions)
+      }
+      this.grid.set(nextPosition, serverInfo)
+    }
+  }
+}
+
+class ExpandingGrid {
+  constructor(center) {
+    this.array = [[center]]
+    this.size = 0
+  }
+
+  map(f) {
+    this.array.map((arr, x) => arr.map((a, z) => f(a,x - this.size,z - this.size)))
+  }
+
+  get(pos) {
+    return this.array[this.size + pos.x][this.size + pos.z]
+  }
+
+  set(pos, val) {
+    this.increaseToSize(Math.max(pos.absX,pos.absZ))
+    this.array[this.size + pos.x][this.size + pos.z] = val
+  }
+
+  increaseToSize(size) {
+    if(size > this.size) {
+      var emptyArr = []
+      for(var i = 0; i < size * 2 + 1; i++) {
+        emptyArr.push(null)
+      }
+      this.array.unshift(emptyArr)
+      this.array.push([...emptyArr])
+      for(var i = 1; i < size * 2; i++) {
+        this.array[i].unshift(null)
+        this.array[i].push(null)
+      }
+      this.size = size
+    }
+  }
+
+  print() {
+    console.log(this.array)
+  }
+}
+
+class Position {
+  constructor(x,z) {
+    this.x = x
+    this.z = z
+    this.absX = Math.abs(x)
+    this.absZ = Math.abs(z)
+  }
+}
+
+module.exports = ChunkMap

--- a/identify.js
+++ b/identify.js
@@ -2,6 +2,7 @@ const Packet = require('./packet.js');
 const ChunkData = require('./packets/serverbound/chunkData.js');
 const PlayerPosition = require('./packets/serverbound/playerPosition.js');
 const LoginSuccess = require('./packets/clientbound/loginSuccess.js');
+const SpawnPlayer = require('./packets/serverbound/spawnPlayer.js');
 const log = require('./utility.js').log
 
 
@@ -14,18 +15,22 @@ function identify(packet, ctx) {
       switch(packet.packetID){
         case 0x22:
           return ChunkData
+        case 0x05:
+          return SpawnPlayer
         case 2:
           return LoginSuccess
         default:
-          log(`Unrecognized packet ID ${packet.packetID}`)
+          //log(`Unrecognized packet ID ${packet.packetID}`)
+          break;
       }
-      //break;
+      break;
     case 1:
       switch(packet.packetID){
         case 0x10:
           return PlayerPosition
         default:
-          log(`Unrecognized packet ID ${packet.packetID}`)
+          //log(`Unrecognized packet ID ${packet.packetID}`)
+          break;
       }
       break;
     default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,11 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "dependencies": {
     "int64-buffer": "^0.99.1007",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "uuid-parse": "^1.1.0"
   },
   "devDependencies": {
     "javascript-state-machine": "^3.1.0"

--- a/packets/clientbound/chunkData.js
+++ b/packets/clientbound/chunkData.js
@@ -50,7 +50,6 @@ class ChunkData extends Packet {
       varIntBuffer(paletteSize), //Palette Size
       arrayBuffer(palette, varIntBuffer) //Palette Entries
     ])
-
   }
 
   static buildSection() {

--- a/packets/clientbound/joinGame.js
+++ b/packets/clientbound/joinGame.js
@@ -5,7 +5,6 @@ const intBuffer = BufferGenerators.intBuffer;
 const unsignedByteBuffer = BufferGenerators.unsignedByteBuffer;
 
 const tempHardcode = {
-  eid: 1,
   gamemode: 1,
   dimension: 0,
   difficulty: 0,
@@ -15,10 +14,10 @@ const tempHardcode = {
 }
 
 class JoinGame extends Packet {
-  constructor(){
+  constructor(eid){
     super()
     this.packetID = 0x25
-    this.eid = tempHardcode.eid
+    this.eid = eid
     this.gamemode = tempHardcode.gamemode
     this.dimension = tempHardcode.dimension
     this.difficulty = tempHardcode.difficulty

--- a/packets/clientbound/newPlayerInfo.js
+++ b/packets/clientbound/newPlayerInfo.js
@@ -1,0 +1,30 @@
+const Packet = require('../../packet.js');
+const BufferGenerators= require('../../bufferGenerators.js');
+const lengthPrefixedStringBuffer = BufferGenerators.lengthPrefixedStringBuffer;
+const unsignedByteBuffer = BufferGenerators.unsignedByteBuffer;
+const varIntBuffer = BufferGenerators.varIntBuffer;
+const uuidBuffer = BufferGenerators.uuidBuffer;
+
+var action = 0 //Add player
+class NewPlayerInfo extends Packet {
+  constructor(players) {
+    super()
+    this.packetID = 0x30
+    this.dataBuffer = Buffer.concat([
+      varIntBuffer(action), //Action
+      varIntBuffer(players.length), //Number of players
+      Buffer.concat(players.map(player => {
+        return Buffer.concat([
+          uuidBuffer(player.uuid),
+          lengthPrefixedStringBuffer(player.username),
+          varIntBuffer(0), //Number of properties
+          varIntBuffer(0), //Gamemode
+          varIntBuffer(40), //Ping
+          unsignedByteBuffer(0) //has display name
+        ])
+      }))
+    ])
+  }
+}
+
+module.exports = NewPlayerInfo

--- a/packets/clientbound/relativeEntityMove.js
+++ b/packets/clientbound/relativeEntityMove.js
@@ -1,0 +1,29 @@
+const Packet = require('../../packet.js');
+const BufferGenerators= require('../../bufferGenerators.js');
+const doubleBuffer = BufferGenerators.doubleBuffer;
+const floatBuffer = BufferGenerators.floatBuffer;
+const unsignedByteBuffer = BufferGenerators.unsignedByteBuffer;
+const varIntBuffer = BufferGenerators.varIntBuffer;
+const shortBuffer = BufferGenerators.shortBuffer;
+
+class RelativeEntityMove extends Packet {
+  constructor(player, oldPosition, position){
+    super()
+    var diffFactor = 128 * 32
+    var deltaX = (position.x - oldPosition.x) * diffFactor
+    var deltaY = (position.y - oldPosition.y) * diffFactor
+    var deltaZ = (position.z - oldPosition.z) * diffFactor
+    this.packetID = 0x28
+    console.log(oldPosition)
+    console.log(position)
+    this.dataBuffer = Buffer.concat([
+      varIntBuffer(player.eid),
+      shortBuffer(deltaX),
+      shortBuffer(deltaY),
+      shortBuffer(deltaZ),
+      unsignedByteBuffer(0)
+    ])
+  }
+}
+
+module.exports = RelativeEntityMove

--- a/packets/clientbound/spawnPlayer.js
+++ b/packets/clientbound/spawnPlayer.js
@@ -1,0 +1,29 @@
+const Packet = require('../../packet.js');
+const BufferGenerators= require('../../bufferGenerators.js');
+const doubleBuffer = BufferGenerators.doubleBuffer;
+const floatBuffer = BufferGenerators.floatBuffer;
+const unsignedByteBuffer = BufferGenerators.unsignedByteBuffer;
+const varIntBuffer = BufferGenerators.varIntBuffer;
+const uuidBuffer = BufferGenerators.uuidBuffer;
+
+class SpawnPlayer extends Packet {
+  constructor(player){
+    super()
+    var ya = 0
+    var p = 0
+    this.packetID = 0x05
+    console.log(`spawning player at x: ${player.x} z: ${player.z}`)
+    this.dataBuffer = Buffer.concat([
+      varIntBuffer(player.eid),
+      uuidBuffer(player.uuid),
+      doubleBuffer(player.x),
+      doubleBuffer(player.y),
+      doubleBuffer(player.z),
+      floatBuffer(ya),
+      floatBuffer(p),
+      unsignedByteBuffer(0xff) //Entity Metadata Terminator
+    ])
+  }
+}
+
+module.exports = SpawnPlayer

--- a/packets/serverbound/spawnPlayer.js
+++ b/packets/serverbound/spawnPlayer.js
@@ -1,0 +1,21 @@
+const Packet = require('../../packet.js');
+const ByteStream = require('../../byteStream.js');
+
+class SpawnPlayer extends Packet {
+  constructor(packet){
+    super()
+    Object.assign(this, packet)
+  }
+
+  localize(x, z) {
+    var bs = new ByteStream(Buffer.from(this.dataBuffer))
+    bs.readVarInt()
+    bs.skipUuid()
+    bs.amendDouble(d => d + 16*x)
+    bs.readDouble()
+    bs.amendDouble(d => d + 16*z)
+    this.dataBuffer = bs.buffer
+  }
+}
+
+module.exports = SpawnPlayer

--- a/player.js
+++ b/player.js
@@ -1,0 +1,25 @@
+const uuid = require('uuid/v1');
+
+var eid = 1
+var spawnX = 8
+var spawnY = 16
+var spawnZ = 8
+
+class Player {
+  constructor(username, socket) {
+    this.username = username
+    this.socket = socket
+    this.uuid = uuid()
+    this.x = spawnX
+    this.y = spawnY
+    this.z = spawnZ
+    this.eid = eid
+    eid++
+  }
+
+  notify(packet) {
+    this.socket.write(packet)
+  }
+}
+
+module.exports = Player

--- a/playerList.js
+++ b/playerList.js
@@ -1,0 +1,22 @@
+const Player = require('./player.js')
+
+class PlayerList {
+  constructor() {
+    this.players = []
+  }
+
+  createPlayer(username, socket) {
+    return new Player(username, socket)
+  }
+
+  addPlayer(player) {
+    console.log(`adding player`)
+    this.players.push(player)
+  }
+
+  notify(packet, exceptEid) {
+    this.players.filter(player => !exceptEid || player.eid != exceptEid).map(p => p.notify(packet))
+  }
+}
+
+module.exports = PlayerList

--- a/server.js
+++ b/server.js
@@ -7,12 +7,15 @@ const port = process.argv.slice(2)[0];
 
 const SocketDataHandler = require('./socketDataHandler.js');
 const ChunkMap = require('./chunkMap.js')
+const PlayerList = require('./playerList.js')
 
 var chunkMap = new ChunkMap()
-chunkMap.allocateServer({ port: 8001, addr: '127.0.0.1' })
+chunkMap.allocateServer({ port: 8000 + 8001 - port, addr: '127.0.0.1' })
+
+var playerList = new PlayerList()
 
 server.on('connection', socket => {
-  var handler = new SocketDataHandler(socket, chunkMap)
+  var handler = new SocketDataHandler(socket, chunkMap, playerList)
 
   socket.on('close', err => {
     handler.close()

--- a/server.js
+++ b/server.js
@@ -6,9 +6,13 @@ const hostname = '127.0.0.1';
 const port = process.argv.slice(2)[0];
 
 const SocketDataHandler = require('./socketDataHandler.js');
+const ChunkMap = require('./chunkMap.js')
+
+var chunkMap = new ChunkMap()
+chunkMap.allocateServer({ port: 8001, addr: '127.0.0.1' })
 
 server.on('connection', socket => {
-  var handler = new SocketDataHandler(socket)
+  var handler = new SocketDataHandler(socket, chunkMap)
 
   socket.on('close', err => {
     handler.close()


### PR DESCRIPTION
The chunk map provides a way for us to decide where to put servers (currently set to be exactly one chunk in size). It has an algorithm for always put them close to the center chunk (your local server).

Now we look at that chunk map to determine what server owns the players current chunk, and send the packet to the appropriate destination. 

Additionally we are no longer stuck with a two server scheme, we connect to all servers that are added in server.js immediately. Of course in the future we would only want to be connected to servers that are within vision range.