### PR TITLE
fixed ghost players issue

### DIFF
--- a/connection/handleLogout.js
+++ b/connection/handleLogout.js
@@ -2,13 +2,29 @@ const log = require('loglevel')
 const DeleteEntities = require('../packets/clientbound/deleteEntities.js')
 const Packet = require('../packet.js');
 
-function handleLogout(connection) {
+function removePlayer(connection) {
+  connection.notify(Packet.write(DeleteEntities,[[connection.player.eid]]))
+}
+
+function localLogout(connection) {
   if(connection.player) {
-    log.debug(`Removing ${connection.player.username} from guests or players`)
     connection.playerList.deletePlayer(connection.player)
-    connection.guestList.deletePlayer(connection.player)
-    connection.notify(Packet.write(DeleteEntities,[[connection.player.eid]]))
+    removePlayer(connection)
   }
 }
 
-module.exports = handleLogout
+function fullLogout(connection) {
+  if(connection.player) {
+    log.debug(`User ${connection.player.username} has exited server`)
+    connection.playerList.deletePlayer(connection.player)
+    connection.guestList.deletePlayer(connection.player)
+    connection.anchorList.deletePlayer(connection.player)
+    log.debug(connection.guestList[connection.player.uuid])
+    removePlayer(connection)
+  }
+}
+
+module.exports = {
+  local: localLogout,
+  full: fullLogout
+}

--- a/connection/socketDataHandler.js
+++ b/connection/socketDataHandler.js
@@ -5,7 +5,8 @@ const log = require('loglevel')
 const Packet = require('../packet.js');
 const handlePreHandshakePacket = require('./handlePreHandshakePacket.js');
 const handleStatusHandshake = require('./handleStatusHandshake.js');
-const handleLogout = require('./handleLogout.js')
+const localLogout = require('./handleLogout.js').local
+const fullLogout = require('./handleLogout.js').full
 const handleLogin = require('./handleLogin.js').local;
 const proxyLogin = require('./handleLogin.js').proxy;
 const serverDataPackets = require('./serverDataPackets.js');
@@ -71,24 +72,20 @@ class SocketDataHandler {
 
     createLocalPlayer(username) {
       this.player = this.playerList.createPlayer(username, this.socket)
-      log.debug(`adding player ${this.player.username} to players`)
     }
 
     createProxyPlayer(username) {
       this.player = this.guestList.createPlayer(username, this.socket)
-      log.debug(`adding player ${this.player.username} to guests`)
     }
 
     removeAnchor() {
-      log.debug(`moving player ${this.player.username} from anchors to players`)
       this.anchorList.deletePlayer(this.player)
       this.playerList.addPlayer(this.player)
     }
 
     anchor() {
-      log.debug(`moving player ${this.player.username} from players to anchors`)
       this.anchorList.addPlayer(this.player)
-      this.logout()
+      localLogout(this)
     }
 
     sendServerData() {
@@ -97,7 +94,8 @@ class SocketDataHandler {
     }
 
     logout() {
-      handleLogout(this)
+      fullLogout(this)
+      if(this.proxy) { this.proxy.destroy() }
     }
 
     write(packet) {

--- a/server.js
+++ b/server.js
@@ -53,6 +53,7 @@ server.on('connection', socket => {
   socket.on('close', err => {
     handler.logout()
     handler.close()
+    socket.destroy()
     if(err){
       log.error(socketLog(socket,'socket closed due to error'))
     } else {


### PR DESCRIPTION
Related issue: https://github.com/DuncanUszkay1/nodecraft/issues/26
Now players are removed from all lists when they die, and all proxys are closed upon disconnection, which allows the other servers to delete this player as well.